### PR TITLE
Continuously check for changes to in-game players ban status with a bulk request

### DIFF
--- a/backend/Script.rbxmx
+++ b/backend/Script.rbxmx
@@ -79,9 +79,9 @@ local function checkBan(player)
 
 		if data.banned == true then
 			if data.reason == nil then
-				player:Kick('You are banned from this place.\nBan Reason: No reason provided!\n\nTovy')
+				player:Kick('You are banned from this place.\n Ban Reason: No reason provided!\n \n Tovy')
 			else
-				player:Kick('You are banned from this place.\nBan Reason:\n'..data.reason..'\n\nTovy')
+				player:Kick('You are banned from this place.\n Ban Reason:\n '..data.reason..'\n \n Tovy')
 			end
 		end
 	end

--- a/backend/Script.rbxmx
+++ b/backend/Script.rbxmx
@@ -18,6 +18,7 @@ local config = {
 	auth = "<api>",
 	
 	bansEnabled = true, --// Set to false if you do not want Tovy to handle bans (This will use less HTTP requests)
+	banCheckRate = 5, --// The interval (seconds) at which Tovy will check for new bans
 	
 	batchSendDataOnServerClose = true, --// Whether or not this script should bulk send leave data once this server has shutdown (This may cause issues with SoftShutdown scripts which relocate players)
 	bulkDataSendInterval = 30, --// The interval (seconds) at which join/leave data will be sent to Tovy
@@ -119,32 +120,34 @@ players.PlayerAdded:Connect(createSession)
 players.PlayerRemoving:Connect(endSession)
 
 --[[ 
-Check for changes to the ban status of players
+	Check for changes to the ban status of in-game players
 ]]--
+task.spawn(function()
+	while true do
+		local success, data = pcall(function()
+			return httpService:GetAsync(config.url..'/bans/bulkcheck', false, {
+				['authorization'] = config.auth
+			})
+		end)
 
-while true do
-	local success, data = pcall(function()
-		return httpService:GetAsync(config.url..'/activity/bancheck', false, {
-			['authorization'] = config.auth
-		})
-	end)
-	
-	if success then
-		-- Decode and check each player
-		data = httpService:JSONDecode(data)
-		for _, player in pairs(data) do
-			local player = players:FindFirstChild(player.userid)
-			if player then
-				checkBan(player)
+		if success then
+			-- Decode and check each player
+			data = httpService:JSONDecode(data).newbans
+			for _, playerid in pairs(data) do
+				local player = players:GetPlayerByUserId(playerid)
+				if player then
+					checkBan(player)
+				end
 			end
+		else
+			-- On failure, wait 10 seconds and try again
+			print("Failed to retrieve Tovy ban data. Waiting 10 seconds before reattempting.", tostring(data))
+			wait(10)
 		end
-	else
-		-- On failure, wait 2 seconds and try again
-		print("Failed to retrieve Tovy ban data:", tostring(data))
-		task.wait(2)
+		wait(config.banCheckRate)
 	end
-	wait(1)
-end
+end)
+
 --[[
 	Ensure all data is sent off before a server is shut down
 ]]--

--- a/backend/Script.rbxmx
+++ b/backend/Script.rbxmx
@@ -118,6 +118,33 @@ players.PlayerAdded:Connect(createSession)
 
 players.PlayerRemoving:Connect(endSession)
 
+--[[ 
+Check for changes to the ban status of players
+]]--
+
+while true do
+	local success, data = pcall(function()
+		return httpService:GetAsync(config.url..'/activity/bancheck', false, {
+			['authorization'] = config.auth
+		})
+	end)
+	
+	if success then
+		-- Decode and check each player
+		data = httpService:JSONDecode(data)
+		for _, player in pairs(data) do
+			local player = players:FindFirstChild(player.userid)
+			if player then
+				checkBan(player)
+			end
+		end
+	else
+		-- On failure, wait 2 seconds and try again
+		print("Failed to retrieve Tovy ban data:", tostring(data))
+		task.wait(2)
+	end
+	wait(1)
+end
 --[[
 	Ensure all data is sent off before a server is shut down
 ]]--

--- a/backend/bans.js
+++ b/backend/bans.js
@@ -46,7 +46,6 @@ const erouter = (cacheEngine, settings, permissions, logging) => {
     const username = await noblox.getUsernameFromId(userid);
     await db.ban.deleteOne({ userid });
     const index = newbans.indexOf(userid);
-    console.log("Searching");
     if (index) newbans.splice(index, 1);
     logging.newLog(`has unbanned ${username}`, req.session.userid);
     res.status(200).json({ success: true });

--- a/backend/bans.js
+++ b/backend/bans.js
@@ -45,9 +45,9 @@ const erouter = (cacheEngine, settings, permissions, logging) => {
     if (!userid) return res.status(400).json({ error: "No userid provided." });
     const username = await noblox.getUsernameFromId(userid);
     await db.ban.deleteOne({ userid });
-    const index = recentbans1.indexOf(userid);
+    const index = newbans.indexOf(userid);
     console.log("Searching");
-    if (index) recentbans1.splice(index, 1);
+    if (index) newbans.splice(index, 1);
     logging.newLog(`has unbanned ${username}`, req.session.userid);
     res.status(200).json({ success: true });
   });

--- a/backend/bans.js
+++ b/backend/bans.js
@@ -32,7 +32,7 @@ const erouter = (cacheEngine, settings, permissions, logging) => {
       permanent: perm ?? false,
     });
     res.status(200).json({ success: true });
-    newbans.push(id)
+    newbans.push(id);
     logging.newLog(
       `has banned **${username}** for **${reason}** ${
         until ? "until " + until : "permanently"
@@ -45,8 +45,8 @@ const erouter = (cacheEngine, settings, permissions, logging) => {
     if (!userid) return res.status(400).json({ error: "No userid provided." });
     const username = await noblox.getUsernameFromId(userid);
     await db.ban.deleteOne({ userid });
-    const index = recentbans1.indexOf(userid)
-    console.log("Searching")
+    const index = recentbans1.indexOf(userid);
+    console.log("Searching");
     if (index) recentbans1.splice(index, 1);
     logging.newLog(`has unbanned ${username}`, req.session.userid);
     res.status(200).json({ success: true });
@@ -91,8 +91,8 @@ const erouter = (cacheEngine, settings, permissions, logging) => {
   });
   router.get("/bulkcheck", async (req, res) => {
     if (req.headers.authorization !== settings.get("activity").key)
-     return res.status(401);
-     return res.json({newbans: newbans});
+      return res.status(401);
+    return res.json({newbans: newbans});
   });
   return router;
 };

--- a/backend/session.js
+++ b/backend/session.js
@@ -231,6 +231,7 @@ const erouter = (cacheEngine, settings, permissions, automation) => {
     let game = await noblox.getUniverseInfo(
       games.filter((m) => m.id).map((m) => m.id)
     ).catch(err => {
+      console.log(err)
       return res.status(500).send({ success: false, error: err.message })
     });
 

--- a/backend/session.js
+++ b/backend/session.js
@@ -230,7 +230,9 @@ const erouter = (cacheEngine, settings, permissions, automation) => {
     let games = settings.get("sessions").games;
     let game = await noblox.getUniverseInfo(
       games.filter((m) => m.id).map((m) => m.id)
-    );
+    ).catch(err => {
+      return res.status(500).send({ success: false, error: err.message })
+    });
 
     res.send(
       games.map((m) => {

--- a/backend/session.js
+++ b/backend/session.js
@@ -230,9 +230,7 @@ const erouter = (cacheEngine, settings, permissions, automation) => {
     let games = settings.get("sessions").games;
     let game = await noblox.getUniverseInfo(
       games.filter((m) => m.id).map((m) => m.id)
-    ).catch(err => {
-      return res.status(500).send({ success: false, error: err.message })
-    });
+    );
 
     res.send(
       games.map((m) => {

--- a/backend/session.js
+++ b/backend/session.js
@@ -231,7 +231,6 @@ const erouter = (cacheEngine, settings, permissions, automation) => {
     let game = await noblox.getUniverseInfo(
       games.filter((m) => m.id).map((m) => m.id)
     ).catch(err => {
-      console.log(err)
       return res.status(500).send({ success: false, error: err.message })
     });
 

--- a/backend/session.js
+++ b/backend/session.js
@@ -230,10 +230,7 @@ const erouter = (cacheEngine, settings, permissions, automation) => {
     let games = settings.get("sessions").games;
     let game = await noblox.getUniverseInfo(
       games.filter((m) => m.id).map((m) => m.id)
-    ).catch(err => {
-      console.log(err)
-      return res.status(500).send({ success: false, error: err.message })
-    });
+    )
 
     res.send(
       games.map((m) => {

--- a/backend/session.js
+++ b/backend/session.js
@@ -230,7 +230,10 @@ const erouter = (cacheEngine, settings, permissions, automation) => {
     let games = settings.get("sessions").games;
     let game = await noblox.getUniverseInfo(
       games.filter((m) => m.id).map((m) => m.id)
-    )
+    ).catch(err => {
+      console.log(err)
+      return res.status(500).send({ success: false, error: err.message })
+    });
 
     res.send(
       games.map((m) => {


### PR DESCRIPTION
Automatically kicks a player from the game server immediately after they're banned through the Tovy instance. Keeps a log of newly banned players on the instance that the game server requests at a specified rate.

The default check rate is 5 seconds, but in a similar system that I use for my groups, the server can easily handle a check rate of 1 second.